### PR TITLE
#8 Update all resources to be fetched over https

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
         <h1>Network map of civil society climate adaptation projects in Vanuatu</h1>
         
         <p>
-            This is a network map of climate adaptation projects in Vanuatu in 2016. Click or hover over an organization or activity to see connections. The Vanuatu Climate Adaptation Network (VCAN) is facilitated by Oxfam - if you have knowledge about projects and organizations to add to the map, please share it with <b>priscillas @ oxfampacific . org</b> , then Priscilla will share it with me to update too. We are also working with <a href="http://www.nab.vu/">Vanuatu’s National Advisory Board on Climate Change and Disaster Risk Reduction</a> to share information.  
+            This is a network map of climate adaptation projects in Vanuatu in 2016. Click or hover over an organization or activity to see connections. The Vanuatu Climate Adaptation Network (VCAN) is facilitated by Oxfam - if you have knowledge about projects and organizations to add to the map, please share it with <b>priscillas @ oxfampacific . org</b> , then Priscilla will share it with me to update too. We are also working with <a href="https://www.nab.vu/">Vanuatu’s National Advisory Board on Climate Change and Disaster Risk Reduction</a> to share information.  
         </p>
         
         <div id="mainText">

--- a/index.html
+++ b/index.html
@@ -6,11 +6,11 @@
         
         <link rel="stylesheet" href="recycle.css" type="text/css" media="screen">
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js" type="text/javascript" charset="utf-8"></script>
-        <script src="paper.js" type="text/javascript" charset="utf-8"></script>
+        <script src="https://cobismith.github.io/climatenetwork/paper.js" type="text/javascript" charset="utf-8"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.1.7/underscore-min.js" type="text/javascript" charset="utf-8"></script>
-        <script src="data.json" type="text/javascript" charset="utf-8"></script>
+        <script src="https://cobismith.github.io/climatenetwork/data.json" type="text/javascript" charset="utf-8"></script>
         
-        <script type="text/paperscript" canvas="canvas" src="recycle.js"></script>
+        <script type="text/paperscript" canvas="canvas" src="https://cobismith.github.io/climatenetwork/recycle.js"></script>
         
         <script type="text/javascript">
             jQuery(document).ready(function() {
@@ -20,9 +20,6 @@
             });
         </script>
         
-        <script type="text/javascript" src="https://use.typekit.net/ran8aft.js"></script>
-<script type="text/javascript">try{Typekit.load();}catch(e){}</script>
-        
         <script type="text/javascript">
             var _gaq = _gaq || [];
             _gaq.push(['_setAccount', 'UA-26336682-1']);
@@ -30,7 +27,7 @@
             
             (function() {
                 var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-                ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+                ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'https://www') + '.google-analytics.com/ga.js';
                 var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
             })();
         </script>
@@ -51,8 +48,8 @@
             <canvas id="canvas" width=1000></canvas>
             
             <p>
-            The code for this infographic is adapted from  <a href="http://www.zackgrossbart.com/blog/more-about-zack/">Zack Grossbart's</a>  <a href="https://github.com/zgrossbart/hborecycling">HBORecycling project on GitHub</a>, which was based on a visualization by Craig Robinson. I've previously adapted it to map knowledge about <a href="https://github.com/cobismith/barriersinfographic">barriers to indigenous media participation in Asia</a> and <a href="https://github.com/cobismith/forestlaws">international forest laws</a>.
-            It's made with <a href="http://www.paperjs.org">PaperJS</a>, <a href="http://documentcloud.github.com/underscore/">underscore.js</a>, and a little <a href="http://jquery.com/">JQuery</a>.
+            The code for this infographic is adapted from  <a href="https://www.zackgrossbart.com/blog/more-about-zack/">Zack Grossbart's</a>  <a href="https://github.com/zgrossbart/hborecycling">HBORecycling project on GitHub</a>, which was based on a visualization by Craig Robinson. I've previously adapted it to map knowledge about <a href="https://github.com/cobismith/barriersinfographic">barriers to indigenous media participation in Asia</a> and <a href="https://github.com/cobismith/forestlaws">international forest laws</a>.
+            It's made with <a href="https://www.paperjs.org">PaperJS</a>, <a href="https://documentcloud.github.com/underscore/">underscore.js</a>, and a little <a href="https://jquery.com/">JQuery</a>.
             </p>
        
        


### PR DESCRIPTION
Resolves #8

- [x] Update all resources to pull from `https`
- [x] Remove `use.typekit.net` as it doesn't appear to be used

This attempts to resolve loading https://cobismith.github.io/climatenetwork/ over `https` by loading all resources over `https` also.

## Notes

`paper.js`, `recycle.js`, and `data.json` now point to github, so if making changes locally temporarily remove the `https://cobismith.github.io/climatenetwork/` prefix.

e.g. To see any changes to `data.json` locally, change: `<script src="https://cobismith.github.io/climatenetwork/data.json" type="text/javascript" charset="utf-8"></script>` to `<script src="data.json" type="text/javascript" charset="utf-8"></script>`